### PR TITLE
Phase 1: 17 new skills + bootstrap upgrades (sales, cross-functional, file utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI GTM Skills for Claude
 
-**16 ready-to-use AI agent skills for go-to-market and revenue leadership.** Meeting prep, prospect research, deal strategy, pipeline health, competitive intel, and more — all running locally in Claude Code.
+**43 ready-to-use AI agent skills for go-to-market and revenue operators.** Sales execution, marketing, competitive intel, file utilities, and daily operator workflows — all running locally in Claude Code.
 
 Built by [Scott Wueschinski](https://linkedin.com/in/scottwueschinski) for the [Pavilion](https://www.joinpavilion.com/) AI in GTM School.
 
@@ -27,7 +27,7 @@ Before installing anything, see what these skills produce:
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/GTMify/aigtm/main/setup/bootstrap.sh)"
 ```
 
-This installs everything — Homebrew, Node.js, Python, Claude Code, and all 16 skills. Takes about 5 minutes. When it finishes, Claude launches automatically and walks you through a 2-minute profile setup.
+This installs everything — Homebrew, Node.js, Python, Claude Code, public CLIs (vercel/stripe/supabase/wrangler/agent-browser), and all skills. Takes about 5-7 minutes. The script optionally walks you through a Bring-Your-Own-Keys `.env` setup, then Claude launches and runs a 2-minute profile setup.
 
 **Already cloned the repo?**
 ```bash
@@ -49,53 +49,120 @@ No terminal needed. Open any skill folder below, copy the prompt from the **`COW
 
 ---
 
-## All 16 Skills
+## Bring Your Own Keys (BYOK)
+
+Most skills work fine with **no API keys** — Claude's built-in WebSearch handles research. But some skills become dramatically more powerful when wired to your own keys (Apollo for contact data, Hunter for email verification, Firecrawl for clean scraping, Vercel for one-click deploys, Stripe for proposal payments, etc.).
+
+The bootstrap script offers an interactive `.env` setup. You can also copy the template manually:
+
+```bash
+cp setup/env.example ~/.claude/.env
+# Edit ~/.claude/.env to fill in only the keys you use
+chmod 600 ~/.claude/.env
+```
+
+The full annotated key catalog with which-skill-uses-which mapping is in [`setup/env.example`](setup/env.example).
+
+The bootstrap script adds a line to your shell profile that auto-loads `~/.claude/.env` into every new terminal session.
+
+---
+
+## All Skills
 
 ### Sales Execution
 
-| Skill | What it does | Time saved |
-|-------|-------------|------------|
-| [Meeting Prep](skills/meeting-prep/) | Researches a company + person and produces a scannable briefing before your call | 15-25 min/call |
-| [Prospect Research](skills/prospect-research/) | Researches target accounts, finds decision-makers, drafts personalized outreach | 30-45 min/batch |
-| [Post-Call Summary](skills/post-call-summary/) | Turns raw call notes into action items, follow-up email, and CRM-ready summary | 15-20 min/call |
-| [Objection Handler](skills/objection-handler/) | Diagnoses stuck deals, prescribes recovery plays, and writes the exact messages to send | Deals saved, not time |
-| [Deal Strategy](skills/deal-strategy/) | MEDDIC assessment, stakeholder map, competitive positioning, and action plan for active deals | 30-45 min/deal |
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| [Meeting Prep](skills/meeting-prep/) | Research a company + person and produce a pre-call briefing | FIRECRAWL, SERPER |
+| [Prospect Research](skills/prospect-research/) | Research target accounts, find decision-makers, draft outreach | APOLLO, HUNTER, FIRECRAWL |
+| [Cold Email](skills/cold-email/) | B2B cold emails with 4-touch follow-up sequences | — |
+| [Sequence](skills/sequence/) | Multi-channel outreach cadence (email + LinkedIn + phone) | SMARTLEAD, INSTANTLY, LEMLIST, HEYREACH |
+| [ABM](skills/abm/) | Account plan with buying committee map and 30-day play | APOLLO, CLEARBIT |
+| [Battlecard](skills/battlecard/) | Honest competitive battlecard against a named competitor | FIRECRAWL, SERPER |
+| [Referral](skills/referral/) | Warm-intro path finder with forwardable 2-message bundle | — |
+| [Post-Call Summary](skills/post-call-summary/) | Raw notes → action items + follow-up + CRM summary | — |
+| [Objection Handler](skills/objection-handler/) | Diagnose stuck deals, prescribe plays, write the messages | — |
+| [Deal Strategy](skills/deal-strategy/) | MEDDIC, stakeholder map, competitive positioning, action plan | — |
+| [Proposal](skills/proposal/) | Customer-facing proposal or SOW with procurement-ready terms | STRIPE |
+| [ROI Calculator](skills/roi-calculator/) | Risk-adjusted business case with CFO Q&A | — |
+| [One-Pager](skills/one-pager/) | Forwardable champion leave-behind doc | BRANDFETCH |
+
+### Marketing
+
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| Launch *(Phase 2)* | Product/feature launch plan + content kit | — |
+| Campaign *(Phase 2)* | Multi-channel marketing campaign builder | — |
+| Messaging *(Phase 2)* | Positioning, value props, message hierarchy | — |
+| PMM *(Phase 2)* | Product-marketing artifact suite | — |
+| Programmatic SEO *(Phase 2)* | Template-based pages at scale | DATAFORSEO |
+| SEO Audit *(Phase 2)* | Technical + on-page SEO diagnostic | GA4, DATAFORSEO |
+| Competitor Alternatives *(Phase 2)* | "[Competitor] alternatives" landing pages | FIRECRAWL |
+| Pricing Strategy *(Phase 2)* | Tiers, packaging, willingness-to-pay analysis | — |
+| Marketing Psychology *(Phase 2)* | Apply mental models to campaigns and copy | — |
+| Kit *(Phase 2)* | Lead magnet content kits | — |
+
+### Cross-Functional
+
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| [Brainstorm](skills/brainstorm/) | Structured multi-frame ideation with ranked output | EXA |
+| [Repurpose](skills/repurpose/) | Turn one asset into 5-10 derivatives across formats | — |
+| [Microsite](skills/microsite/) | Self-contained personalized HTML landing page | VERCEL, CLOUDFLARE, BRANDFETCH |
+| [Changelog](skills/changelog/) | User-facing release notes from git history | — |
+| [Decision Log](skills/decision-log/) | ADR-style decision capture | — |
+| [Roadmap](skills/roadmap/) | Prioritized roadmap with Now/Next/Later tiers | — |
 
 ### Pipeline & Forecasting
 
-| Skill | What it does | Time saved |
-|-------|-------------|------------|
-| [Pipeline Health](skills/pipeline-health/) | Audits your pipeline for stuck deals, single-threading, and coverage gaps | 30-60 min/week |
-| [Forecast Narrative](skills/forecast-narrative/) | Translates pipeline data into a commit/upside/risk narrative for your CRO or board | 45-60 min/cycle |
-| [Territory Analyzer](skills/territory-analyzer/) | Team-level view of rep performance, coverage gaps, whitespace, and reallocation recommendations | 1-2 hours/review |
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| [Pipeline Health](skills/pipeline-health/) | Audit pipeline for stuck deals and coverage gaps | SALESFORCE, HUBSPOT |
+| [Forecast Narrative](skills/forecast-narrative/) | Pipeline data → commit/upside/risk narrative | SALESFORCE, HUBSPOT |
+| [Territory Analyzer](skills/territory-analyzer/) | Team-level performance, coverage, whitespace | SALESFORCE, HUBSPOT |
 
 ### Competitive & Market Intelligence
 
-| Skill | What it does | Time saved |
-|-------|-------------|------------|
-| [Competitive Intel](skills/competitive-intel/) | Monitors competitors for product launches, hiring signals, press, and pricing changes | 1-2 hours/week |
-| [Win/Loss Analyzer](skills/win-loss-analyzer/) | Analyzes deal outcomes for patterns, loss reasons, and actionable takeaways | 2-3 hours/quarter |
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| [Competitive Intel](skills/competitive-intel/) | Monitor competitors for launches, hiring, press | FIRECRAWL, SERPER |
+| [Win/Loss Analyzer](skills/win-loss-analyzer/) | Analyze deal outcomes for patterns | — |
 
 ### Customer Success & Retention
 
-| Skill | What it does | Time saved |
-|-------|-------------|------------|
-| [QBR Builder](skills/qbr-builder/) | Builds customer-facing quarterly business reviews that lead with value, not features | 2-3 hours/QBR |
-| [Churn Early Warning](skills/churn-early-warning/) | Flags at-risk accounts by revenue impact and prescribes save plays before renewal | Catches risk 60-90 days earlier |
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| [QBR Builder](skills/qbr-builder/) | Customer-facing QBR that leads with value | — |
+| [Churn Early Warning](skills/churn-early-warning/) | Flag at-risk accounts, prescribe save plays | SALESFORCE, HUBSPOT |
 
 ### Leadership & Strategy
 
-| Skill | What it does | Time saved |
-|-------|-------------|------------|
-| [Board Update](skills/board-update/) | Builds structured board or investor updates with revenue, pipeline, team, and strategic narrative | 2-3 hours/update |
-| [Hiring Brief](skills/hiring-brief/) | Scopes a role, writes a JD, provides comp guidance, and builds an interview scorecard | 3-4 hours/role |
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| [Board Update](skills/board-update/) | Investor update with revenue, pipeline, narrative | — |
+| [Hiring Brief](skills/hiring-brief/) | Role scope + JD + comp + interview scorecard | — |
 
-### Productivity
+### Daily Operations
 
-| Skill | What it does | Time saved |
-|-------|-------------|------------|
-| [Weekly Planner](skills/weekly-planner/) | Synthesizes calendar, pipeline, and priorities into a focused weekly game plan | 30-45 min/week |
-| [Inbox Triage](skills/inbox-triage/) | Categorizes, prioritizes, and drafts responses for your email backlog | 20-30 min/day |
+| Skill | What it does | Optional keys |
+|-------|--------------|---------------|
+| [Weekly Planner](skills/weekly-planner/) | Calendar + pipeline + priorities → weekly game plan | — |
+| [Inbox Triage](skills/inbox-triage/) | Categorize, prioritize, draft email responses | — |
+| CRM *(Phase 3)* | Daily priorities dashboard from pasted CRM data | — |
+| Standup *(Phase 3)* | Morning brief that surfaces priorities and follow-ups | — |
+| Inbox Zero *(Phase 3)* | Triage assistant for pasted email subjects/threads | — |
+| Focus Time *(Phase 3)* | Time-block planner from pasted calendar | — |
+
+### File Utilities
+
+| Skill | What it does | Libraries |
+|-------|--------------|-----------|
+| [xlsx](skills/xlsx/) | Read/edit/create Excel and CSV spreadsheets | openpyxl, pandas |
+| [docx](skills/docx/) | Read/edit/create Word documents | python-docx, Pillow |
+| [pdf](skills/pdf/) | Extract/merge/split/create/OCR PDFs | pypdf, pdfplumber, weasyprint, ocrmypdf |
+| [pptx](skills/pptx/) | Read/edit/create PowerPoint decks | python-pptx |
+
+> *Phase 2 (marketing) and Phase 3 (daily operations) skills land in separate PRs and bring the total to 43.*
 
 ---
 
@@ -144,6 +211,12 @@ Check that skills are linked: `ls ~/.claude/skills/`. If empty, re-run `./setup/
 **"Permission denied" on Windows symlinks**
 Enable Developer Mode: Settings > Privacy & Security > For developers > Developer Mode. Or run PowerShell as Administrator.
 
+**Env vars not loading in my shell**
+The bootstrap adds a block to `~/.zshrc` (or PowerShell profile) that auto-sources `~/.claude/.env`. If you skipped that step, run `./setup/bootstrap.sh` again or add this line manually:
+```bash
+set -a; . ~/.claude/.env; set +a
+```
+
 **Want to verify your setup?**
 ```bash
 ./setup/bootstrap.sh --check    # macOS
@@ -156,7 +229,7 @@ Enable Developer Mode: Settings > Privacy & Security > For developers > Develope
 
 Built by [Scott Wueschinski](https://linkedin.com/in/scottwueschinski) for the Pavilion AI in GTM School. Questions? Reach out at scott@gtmify.io.
 
-These skills use Claude's built-in web search and file tools. No API keys, external services, or coding required for the Desktop/Cowork prompts. Claude Code skills may optionally use MCP servers for CRM integration.
+Skills use Claude's built-in web search and file tools out of the box. Optional API keys (Apollo, Hunter, Firecrawl, Vercel, Stripe, etc.) supercharge specific skills — see [`setup/env.example`](setup/env.example) for the full catalog.
 
 ---
 

--- a/setup/bootstrap.ps1
+++ b/setup/bootstrap.ps1
@@ -15,9 +15,11 @@
 #   Phase 3: Developer tools (fnm, jq, gh, fzf, bat, ripgrep, fd, tree)
 #   Phase 4: Node.js 24 + Python 3.13
 #   Phase 5: Claude Code CLI
-#   Phase 6: AI GTM Skills (16 skills linked to ~/.claude/skills/)
-#   Phase 7: GitHub authentication
-#   Phase 8: PowerShell profile configuration
+#   Phase 6: Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)
+#   Phase 7: Bring Your Own Keys (.env setup)
+#   Phase 8: AI GTM Skills (linked to ~/.claude/skills/)
+#   Phase 9: GitHub authentication
+#   Phase 10: PowerShell profile configuration
 #
 # After setup, run 'claude' to start. On first launch, Claude walks you
 # through a 2-minute profile setup — your role, company, ICP, and competitors.
@@ -33,7 +35,7 @@ $FNM_NODE_VERSION = "24"
 $PYTHON_VERSION = "3.13"
 $CLAUDE_DIR = "$env:USERPROFILE\.claude"
 $WORKSPACE = "$env:USERPROFILE\claude"
-$TOTAL_PHASES = 8
+$TOTAL_PHASES = 10
 $script:Failed = 0
 
 # ── Helpers ────────────────────────────────────────────────────
@@ -94,20 +96,31 @@ if ($Check) {
     Write-Phase 5 "Claude Code"
     Check-Tool "Claude Code" "claude"
 
-    Write-Phase 6 "Skills"
+    Write-Phase 6 "Public CLIs (optional)"
+    Check-Tool "vercel" "vercel"
+    Check-Tool "stripe" "stripe"
+    Check-Tool "supabase" "supabase"
+    Check-Tool "wrangler" "wrangler"
+    Check-Tool "agent-browser" "agent-browser"
+
+    Write-Phase 7 ".env file"
+    if (Test-Path "$CLAUDE_DIR\.env") { Write-Ok ".env present at ~/.claude/.env" }
+    else { Write-Warn "No ~/.claude/.env yet - most skills work without it" }
+
+    Write-Phase 8 "Skills"
     $skillCount = 0
     if (Test-Path "$CLAUDE_DIR\skills") {
         $skillCount = (Get-ChildItem "$CLAUDE_DIR\skills" -Directory -ErrorAction SilentlyContinue).Count
     }
     if ($skillCount -ge 16) { Write-Ok "Skills installed ($skillCount linked)" }
-    elseif ($skillCount -gt 0) { Write-Warn "Only $skillCount skills linked (expected 16)"; $issues++ }
+    elseif ($skillCount -gt 0) { Write-Warn "Only $skillCount skills linked (expected 16+)"; $issues++ }
     else { Write-Fail "No skills installed"; $issues++ }
 
-    Write-Phase 7 "GitHub auth"
+    Write-Phase 9 "GitHub auth"
     $ghAuth = gh auth status 2>&1
     if ($LASTEXITCODE -eq 0) { Write-Ok "GitHub authenticated" } else { Write-Fail "Not authenticated"; $issues++ }
 
-    Write-Phase 8 "Shell + profile"
+    Write-Phase 10 "Shell + profile"
     if ((Test-Path $PROFILE) -and (Select-String -Path $PROFILE -Pattern "AIGTM_BOOTSTRAP_START" -Quiet)) {
         Write-Ok "PowerShell profile configured"
     } else { Write-Warn "Profile not configured"; $issues++ }
@@ -136,8 +149,10 @@ Write-Host "  run AI-powered GTM skills in Claude Code."
 Write-Host ""
 Write-Host "  What gets installed:"
 Write-Host "    - Developer tools (Git, Node.js, Python)"
+Write-Host "    - Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)"
 Write-Host "    - Claude Code CLI"
-Write-Host "    - 16 AI GTM skills for sales, pipeline, and strategy"
+Write-Host "    - AI GTM skills for sales, marketing, and operations"
+Write-Host "    - Optional .env scaffold for Bring Your Own Keys (BYOK)"
 Write-Host ""
 
 if (-not $Yes) {
@@ -236,8 +251,99 @@ if (Test-Command claude) {
     }
 }
 
-# ── Phase 6: Skills ───────────────────────────────────────────
-Write-Phase 6 "AI GTM Skills"
+# ── Phase 6: Public CLIs ──────────────────────────────────────
+Write-Phase 6 "Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)"
+
+function Install-NpmGlobal {
+    param($pkg, $cmd)
+    if (-not $cmd) { $cmd = $pkg }
+    if (Test-Command $cmd) {
+        Write-Ok "$cmd already installed"
+    } else {
+        if (Test-Command npm) {
+            Write-Info "Installing $pkg via npm..."
+            npm install -g $pkg 2>$null | Out-Null
+            if (Test-Command $cmd) { Write-Ok "$cmd installed" }
+            else { Write-Warn "$pkg install failed (optional)" }
+        } else {
+            Write-Warn "npm not available - skipping $pkg"
+        }
+    }
+}
+
+Install-NpmGlobal "vercel" "vercel"
+Install-NpmGlobal "stripe" "stripe"
+Install-NpmGlobal "supabase" "supabase"
+Install-NpmGlobal "wrangler" "wrangler"
+Install-NpmGlobal "agent-browser" "agent-browser"
+
+# ── Phase 7: BYOK .env setup ──────────────────────────────────
+Write-Phase 7 "Bring Your Own Keys (.env setup)"
+
+$envFile = "$CLAUDE_DIR\.env"
+$envExample = Join-Path $RepoDir "setup\env.example"
+
+New-Item -Path $CLAUDE_DIR -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
+
+if (Test-Path $envFile) {
+    Write-Ok ".env already exists at $envFile (skipping interactive setup)"
+} elseif ($Yes) {
+    if (Test-Path $envExample) {
+        Copy-Item $envExample $envFile
+        Write-Ok "Copied env.example to $envFile (auto-yes mode - edit manually to fill keys)"
+    } else {
+        Write-Warn "env.example not found in repo - skipping .env scaffold"
+    }
+} else {
+    Write-Host ""
+    Write-Host "  Most skills work without any API keys - Claude's built-in WebSearch"
+    Write-Host "  handles research. But some skills can be supercharged with your own"
+    Write-Host "  keys (Apollo, Hunter, Firecrawl, Vercel, Stripe, etc.)."
+    Write-Host ""
+    $envAnswer = Read-Host "  Set up .env with your API keys now? [y/N]"
+
+    if ($envAnswer -match '^[Yy]') {
+        if (Test-Path $envExample) {
+            Copy-Item $envExample $envFile
+            Write-Ok "Copied template to $envFile"
+
+            Write-Host ""
+            Write-Host "  I'll prompt you for the most common keys. Press Enter to skip any."
+            Write-Host ""
+
+            function Set-EnvKey {
+                param($var, $desc)
+                $val = Read-Host "    $var ($desc)"
+                if ($val) {
+                    $content = Get-Content $envFile
+                    $content = $content -replace "^$var=.*", "$var=$val"
+                    Set-Content -Path $envFile -Value $content
+                    Write-Ok "Set $var"
+                }
+            }
+
+            Set-EnvKey "ANTHROPIC_API_KEY" "Anthropic API"
+            Set-EnvKey "OPENAI_API_KEY" "OpenAI API"
+            Set-EnvKey "FIRECRAWL_API_KEY" "Firecrawl (web scraping)"
+            Set-EnvKey "SERPER_API_KEY" "Serper (Google search)"
+            Set-EnvKey "APOLLO_API_KEY" "Apollo (B2B contacts)"
+            Set-EnvKey "HUNTER_API_KEY" "Hunter (email finder)"
+            Set-EnvKey "HUBSPOT_API_KEY" "HubSpot CRM"
+            Set-EnvKey "VERCEL_TOKEN" "Vercel (deploys)"
+            Set-EnvKey "STRIPE_SECRET_KEY" "Stripe"
+
+            Write-Ok ".env saved"
+            Write-Host "  Edit $envFile anytime to add more keys." -ForegroundColor DarkGray
+        } else {
+            Write-Fail "env.example not found at $envExample"
+        }
+    } else {
+        Write-Info "Skipped .env setup - copy setup\env.example to ~/.claude/.env later"
+    }
+}
+
+# ── Phase 8: Skills ───────────────────────────────────────────
+Write-Phase 8 "AI GTM Skills"
 
 # Check for Developer Mode (required for symlinks without admin)
 $devMode = $false
@@ -279,8 +385,8 @@ if (Test-Path $skillsSource) {
     Write-Fail "Skills directory not found at $skillsSource"
 }
 
-# ── Phase 7: GitHub auth ──────────────────────────────────────
-Write-Phase 7 "GitHub authentication"
+# ── Phase 9: GitHub auth ──────────────────────────────────────
+Write-Phase 9 "GitHub authentication"
 
 $ghAuth = gh auth status 2>&1
 if ($LASTEXITCODE -eq 0) {
@@ -298,8 +404,8 @@ if ($LASTEXITCODE -eq 0) {
     }
 }
 
-# ── Phase 8: PowerShell profile ───────────────────────────────
-Write-Phase 8 "Shell configuration"
+# ── Phase 10: PowerShell profile ──────────────────────────────
+Write-Phase 10 "Shell configuration"
 
 $profileBlock = @'
 # === AIGTM_BOOTSTRAP_START ===
@@ -322,6 +428,20 @@ if (Get-Command npm -ErrorAction SilentlyContinue) {
 Set-Alias -Name gs -Value "git status" -Option AllScope -ErrorAction SilentlyContinue
 function gl { git log --oneline -20 }
 function gd { git diff }
+
+# ── BYOK env vars from ~/.claude/.env ──
+$envFile = "$env:USERPROFILE\.claude\.env"
+if (Test-Path $envFile) {
+    Get-Content $envFile | ForEach-Object {
+        if ($_ -match "^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
+            $name = $Matches[1]
+            $value = $Matches[2].Trim()
+            if ($value -ne "") {
+                Set-Item -Path "env:$name" -Value $value -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
 
 # === AIGTM_BOOTSTRAP_END ===
 '@

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -19,9 +19,11 @@
 #   Phase 3: Developer tools (mise, jq, gh, fzf, bat, ripgrep, fd, tree)
 #   Phase 4: Node.js 24 + Python 3.13 (via mise)
 #   Phase 5: Claude Code CLI
-#   Phase 6: AI GTM Skills (16 skills linked to ~/.claude/skills/)
-#   Phase 7: GitHub authentication
-#   Phase 8: Shell configuration
+#   Phase 6: Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)
+#   Phase 7: Bring Your Own Keys (.env setup)
+#   Phase 8: AI GTM Skills (linked to ~/.claude/skills/)
+#   Phase 9: GitHub authentication
+#   Phase 10: Shell configuration
 #
 # After setup, run 'claude' to start. On first launch, Claude walks you
 # through a 2-minute profile setup — your role, company, ICP, and competitors.
@@ -33,7 +35,7 @@ MISE_NODE_VERSION="24"
 MISE_PYTHON_VERSION="3.13"
 CLAUDE_DIR="$HOME/.claude"
 WORKSPACE="$HOME/claude"
-TOTAL_PHASES=8
+TOTAL_PHASES=10
 FAILED=0
 
 # ── Colors ─────────────────────────────────────────────────────
@@ -157,7 +159,21 @@ run_check() {
   phase 5 "Claude Code"
   check "Claude Code"  "has_cmd claude"
 
-  phase 6 "Skills"
+  phase 6 "Public CLIs (optional)"
+  check "vercel"       "has_cmd vercel"
+  check "stripe"       "has_cmd stripe"
+  check "supabase"     "has_cmd supabase"
+  check "wrangler"     "has_cmd wrangler"
+  check "agent-browser" "has_cmd agent-browser"
+
+  phase 7 ".env file"
+  if [ -f "$CLAUDE_DIR/.env" ]; then
+    ok ".env present at ~/.claude/.env"
+  else
+    warn "No ~/.claude/.env yet — most skills work without it"
+  fi
+
+  phase 8 "Skills"
   local skill_count=0
   if [ -d "$CLAUDE_DIR/skills" ]; then
     skill_count=$(find "$CLAUDE_DIR/skills" -maxdepth 1 -mindepth 1 \( -type d -o -type l \) 2>/dev/null | wc -l | tr -d ' ')
@@ -165,14 +181,14 @@ run_check() {
   if [ "$skill_count" -ge 16 ]; then
     ok "Skills installed ($skill_count linked)"
   elif [ "$skill_count" -gt 0 ]; then
-    warn "Only $skill_count skills linked (expected 16)"
+    warn "Only $skill_count skills linked (expected 16+)"
     issues=$((issues + 1))
   else
     fail "No skills installed"
     issues=$((issues + 1))
   fi
 
-  phase 7 "GitHub auth"
+  phase 9 "GitHub auth"
   if gh auth status &>/dev/null 2>&1; then
     local gh_user
     gh_user=$(gh auth status 2>&1 | grep -oE 'Logged in to github.com as [^ ]+' | awk '{print $NF}')
@@ -182,7 +198,7 @@ run_check() {
     issues=$((issues + 1))
   fi
 
-  phase 8 "Shell + profile"
+  phase 10 "Shell + profile"
   if [ -f "$HOME/.zshrc" ] && grep -q "AIGTM_BOOTSTRAP_START" "$HOME/.zshrc"; then
     ok "Shell configured"
   else
@@ -225,8 +241,10 @@ echo "  run AI-powered GTM skills in Claude Code."
 echo
 echo "  What gets installed:"
 echo "    - Developer tools (Homebrew, Node.js, Python)"
+echo "    - Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)"
 echo "    - Claude Code CLI"
-echo "    - 16 AI GTM skills for sales, pipeline, and strategy"
+echo "    - AI GTM skills for sales, marketing, and operations"
+echo "    - Optional .env scaffold for Bring Your Own Keys (BYOK)"
 echo
 
 if ! $AUTO_YES; then
@@ -403,8 +421,115 @@ else
   fi
 fi
 
-# ── Phase 6: Repo + Skills ────────────────────────────────────
-phase 6 "AI GTM Skills"
+# ── Phase 6: Public CLIs ───────────────────────────────────────
+phase 6 "Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)"
+
+npm_install_global() {
+  local pkg="$1" cmd="${2:-$1}"
+  if has_cmd "$cmd"; then
+    ok "$cmd already installed"
+  else
+    info "Installing $pkg via npm..."
+    if npm install -g "$pkg" >/dev/null 2>&1; then
+      if has_cmd "$cmd"; then
+        ok "$cmd installed"
+      else
+        warn "$pkg installed but '$cmd' not on PATH yet"
+      fi
+    else
+      warn "$pkg install failed — skip (optional)"
+    fi
+  fi
+}
+
+if has_cmd npm; then
+  npm_install_global vercel
+  npm_install_global stripe
+  npm_install_global supabase
+  npm_install_global wrangler
+  npm_install_global agent-browser
+else
+  warn "npm not available — skipping public CLI installs"
+fi
+
+# ── Phase 7: Interactive .env setup (BYOK) ─────────────────────
+phase 7 "Bring Your Own Keys (.env setup)"
+
+ENV_FILE="$CLAUDE_DIR/.env"
+ENV_EXAMPLE="$REPO_DIR/setup/env.example"
+
+mkdir -p "$CLAUDE_DIR"
+
+if [ -f "$ENV_FILE" ]; then
+  ok ".env already exists at $ENV_FILE (skipping interactive setup)"
+elif $AUTO_YES; then
+  if [ -f "$ENV_EXAMPLE" ]; then
+    cp "$ENV_EXAMPLE" "$ENV_FILE"
+    chmod 600 "$ENV_FILE"
+    ok "Copied env.example to $ENV_FILE (auto-yes mode — edit manually to fill keys)"
+  else
+    warn "env.example not found in repo — skipping .env scaffold"
+  fi
+else
+  echo
+  echo "  Most skills work without any API keys — Claude's built-in WebSearch"
+  echo "  handles research. But some skills can be supercharged with your own"
+  echo "  keys (Apollo, Hunter, Firecrawl, Vercel, Stripe, etc.)."
+  echo
+  echo -en "  ${BOLD}Set up .env with your API keys now?${NC} [y/N] "
+  read -r env_answer
+
+  case "$env_answer" in
+    [Yy]*)
+      if [ -f "$ENV_EXAMPLE" ]; then
+        cp "$ENV_EXAMPLE" "$ENV_FILE"
+        chmod 600 "$ENV_FILE"
+        ok "Copied template to $ENV_FILE"
+
+        echo
+        echo "  I'll prompt you for the most common keys. Press Enter to skip any."
+        echo "  All values are stored locally in $ENV_FILE (chmod 600, gitignored)."
+        echo
+
+        prompt_key() {
+          local var="$1" desc="$2"
+          echo -en "    ${BLUE}$var${NC} ($desc): "
+          read -r value
+          if [ -n "$value" ]; then
+            awk -v k="$var" -v v="$value" '
+              $0 ~ "^"k"=" { print k"="v; next }
+              { print }
+            ' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+            ok "Set $var"
+          fi
+        }
+
+        prompt_key "ANTHROPIC_API_KEY" "Anthropic API"
+        prompt_key "OPENAI_API_KEY" "OpenAI API"
+        prompt_key "FIRECRAWL_API_KEY" "Firecrawl (web scraping)"
+        prompt_key "SERPER_API_KEY" "Serper (Google search)"
+        prompt_key "APOLLO_API_KEY" "Apollo (B2B contacts)"
+        prompt_key "HUNTER_API_KEY" "Hunter (email finder)"
+        prompt_key "HUBSPOT_API_KEY" "HubSpot CRM"
+        prompt_key "VERCEL_TOKEN" "Vercel (deploys)"
+        prompt_key "STRIPE_SECRET_KEY" "Stripe"
+
+        chmod 600 "$ENV_FILE"
+        ok ".env saved (chmod 600)"
+        echo
+        echo "  ${DIM}Edit $ENV_FILE anytime to add more keys.${NC}"
+      else
+        fail "env.example not found at $ENV_EXAMPLE"
+      fi
+      ;;
+    *)
+      info "Skipped .env setup — you can copy setup/env.example to ~/.claude/.env later"
+      ;;
+  esac
+fi
+
+# ── Phase 8: Repo + Skills ────────────────────────────────────
+phase 8 "AI GTM Skills"
 
 # If we came from curl, clone the repo first
 if $FROM_CURL; then
@@ -478,8 +603,8 @@ else
   fi
 fi
 
-# ── Phase 7: GitHub auth ──────────────────────────────────────
-phase 7 "GitHub authentication"
+# ── Phase 9: GitHub auth ──────────────────────────────────────
+phase 9 "GitHub authentication"
 
 if gh auth status &>/dev/null 2>&1; then
   local_gh_user=$(gh auth status 2>&1 | grep -oE 'Logged in to github.com as [^ ]+' | awk '{print $NF}')
@@ -499,8 +624,8 @@ else
   fi
 fi
 
-# ── Phase 8: Shell configuration ──────────────────────────────
-phase 8 "Shell configuration"
+# ── Phase 10: Shell configuration ─────────────────────────────
+phase 10 "Shell configuration"
 
 zshrc="$HOME/.zshrc"
 managed_block=$(cat << 'SHELL_BLOCK'
@@ -538,6 +663,13 @@ export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 alias gs="git status"
 alias gl="git log --oneline -20"
 alias gd="git diff"
+
+# ── BYOK env vars from ~/.claude/.env ──
+if [ -f "$HOME/.claude/.env" ]; then
+  set -a
+  . "$HOME/.claude/.env"
+  set +a
+fi
 
 # === AIGTM_BOOTSTRAP_END ===
 SHELL_BLOCK

--- a/setup/env.example
+++ b/setup/env.example
@@ -1,0 +1,217 @@
+# =============================================================================
+#  AI GTM Skills — Environment Variable Template
+# =============================================================================
+#
+# Copy this file to ~/.claude/.env and fill in only the keys you need.
+# Skills work with Claude's built-in WebSearch out of the box — most env vars
+# here are optional and only required if you want to plug in a specific
+# external service.
+#
+# To load these into Claude Code, the bootstrap script adds a line to your
+# ~/.zshrc that sources ~/.claude/.env if it exists.
+#
+# Bring Your Own Keys (BYOK) — none of these keys come from this repo. You
+# provide your own from each vendor's dashboard.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+#  Core LLM access (most skills don't need this — Claude Code handles auth —
+#  but you can wire in alternate models if a skill calls out to one)
+# -----------------------------------------------------------------------------
+
+# Anthropic API key (only if you call Claude API directly outside Claude Code)
+# Used by: any custom scripts you write
+# Get one: https://console.anthropic.com/
+ANTHROPIC_API_KEY=
+
+# OpenAI API key (only if a skill or your custom script uses GPT models)
+# Used by: any custom scripts you write
+# Get one: https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+
+
+# -----------------------------------------------------------------------------
+#  Web research and search
+# -----------------------------------------------------------------------------
+
+# Firecrawl — web scraping with markdown output, handles JS-rendered pages
+# Used by: prospect-research, competitive-intel, meeting-prep (optional upgrade
+#   from native WebSearch — Firecrawl gives cleaner pages and bypasses some
+#   anti-bot defenses)
+# Get one: https://firecrawl.dev
+FIRECRAWL_API_KEY=
+
+# Serper — Google search results as JSON
+# Used by: prospect-research, competitive-intel (faster than WebSearch for
+#   high-volume queries)
+# Get one: https://serper.dev
+SERPER_API_KEY=
+
+# Exa — neural search and semantic retrieval
+# Used by: brainstorm, repurpose (find related/adjacent content)
+# Get one: https://exa.ai
+EXA_API_KEY=
+
+
+# -----------------------------------------------------------------------------
+#  Prospecting and contact data
+# -----------------------------------------------------------------------------
+
+# Apollo.io — B2B contact and company database
+# Used by: prospect-research, abm, sequence (find decision-makers)
+# Get one: https://apollo.io
+APOLLO_API_KEY=
+
+# Hunter — email finder and verifier
+# Used by: prospect-research, sequence (verify deliverability before sending)
+# Get one: https://hunter.io
+HUNTER_API_KEY=
+
+# Findymail — email finder with high accuracy
+# Used by: prospect-research, sequence (alternative to Hunter)
+# Get one: https://findymail.com
+FINDYMAIL_API_KEY=
+
+# RocketReach — contact intelligence
+# Used by: prospect-research (alternative provider)
+# Get one: https://rocketreach.co
+ROCKETREACH_API_KEY=
+
+# Clearbit — company enrichment from a domain
+# Used by: prospect-research, abm (firmographic data)
+# Get one: https://clearbit.com
+CLEARBIT_API_KEY=
+
+
+# -----------------------------------------------------------------------------
+#  CRM, calendar, and email integrations
+# -----------------------------------------------------------------------------
+
+# Salesforce — CRM (used by skills that ingest pipeline data)
+# Used by: pipeline-health, forecast-narrative, territory-analyzer, crm
+# Note: Salesforce typically uses OAuth — these are for API/integration users
+SALESFORCE_CLIENT_ID=
+SALESFORCE_CLIENT_SECRET=
+SALESFORCE_USERNAME=
+SALESFORCE_PASSWORD=
+SALESFORCE_SECURITY_TOKEN=
+SALESFORCE_DOMAIN=login    # or "test" for sandbox
+
+# HubSpot — CRM and marketing
+# Used by: pipeline-health, crm, campaign
+# Get one: https://app.hubspot.com/private-apps
+HUBSPOT_API_KEY=
+
+# Google (Gmail + Calendar + Drive)
+# Used by: inbox-zero, focus-time, standup, crm
+# Path to OAuth client JSON (download from Google Cloud Console)
+GOOGLE_OAUTH_CLIENT_JSON=~/.claude/google-oauth-client.json
+
+# Microsoft 365 (Outlook + Calendar)
+# Used by: inbox-zero, focus-time, standup
+MS365_CLIENT_ID=
+MS365_TENANT_ID=
+MS365_CLIENT_SECRET=
+
+
+# -----------------------------------------------------------------------------
+#  Outreach platforms
+# -----------------------------------------------------------------------------
+
+# Smartlead — cold email infrastructure
+# Used by: cold-email, sequence
+# Get one: https://smartlead.ai
+SMARTLEAD_API_KEY=
+
+# Instantly — cold email platform
+# Used by: cold-email, sequence
+# Get one: https://instantly.ai
+INSTANTLY_API_KEY=
+
+# lemlist — outreach platform
+# Used by: cold-email, sequence
+# Get one: https://lemlist.com
+LEMLIST_API_KEY=
+
+# Reply.io — outreach platform
+# Used by: cold-email, sequence
+# Get one: https://reply.io
+REPLY_API_KEY=
+
+# HeyReach — LinkedIn outreach
+# Used by: sequence, abm
+# Get one: https://heyreach.io
+HEYREACH_API_KEY=
+
+
+# -----------------------------------------------------------------------------
+#  Hosting and deployment (for microsite, one-pager, programmatic-seo)
+# -----------------------------------------------------------------------------
+
+# Vercel — preview and production deployments
+# Used by: microsite, programmatic-seo (deploy generated HTML pages)
+# Get one: https://vercel.com/account/tokens
+VERCEL_TOKEN=
+VERCEL_TEAM_ID=
+
+# Cloudflare — DNS and Pages
+# Used by: microsite (custom subdomains, edge deployment)
+# Get one: https://dash.cloudflare.com/profile/api-tokens
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ACCOUNT_ID=
+
+# Supabase — managed Postgres + storage
+# Used by: any custom skill that needs a backend (none of the default 43 skills
+#   depend on this, but bootstrap installs the CLI for future use)
+# Get one: https://supabase.com/dashboard/account/tokens
+SUPABASE_ACCESS_TOKEN=
+
+
+# -----------------------------------------------------------------------------
+#  Payments and billing (proposal, roi-calculator handoff)
+# -----------------------------------------------------------------------------
+
+# Stripe — payments
+# Used by: proposal (pricing links), pricing-strategy (export pricing tables)
+# Get one: https://dashboard.stripe.com/apikeys
+STRIPE_SECRET_KEY=
+STRIPE_PUBLISHABLE_KEY=
+
+
+# -----------------------------------------------------------------------------
+#  Marketing, SEO, analytics
+# -----------------------------------------------------------------------------
+
+# Ahrefs / Semrush / DataForSEO — keyword research and rank tracking
+# Used by: seo-audit, programmatic-seo, competitor-alternatives
+DATAFORSEO_LOGIN=
+DATAFORSEO_PASSWORD=
+AHREFS_API_KEY=
+
+# Google Analytics 4 — measurement
+# Used by: seo-audit, analytics-tracking
+# Service account JSON path
+GA4_SERVICE_ACCOUNT_JSON=
+
+# Brandfetch — pull logos and brand colors from a domain
+# Used by: microsite, one-pager (auto-fill customer logos)
+# Get one: https://brandfetch.com
+BRANDFETCH_API_KEY=
+
+
+# -----------------------------------------------------------------------------
+#  Notes
+# -----------------------------------------------------------------------------
+#
+# 1. Most skills work fine with no keys at all — Claude's built-in WebSearch
+#    handles research. Only fill in keys for the integrations you actually use.
+#
+# 2. Never commit ~/.claude/.env to git. The repo's .gitignore protects this
+#    but verify before any commit.
+#
+# 3. Rotate keys regularly. If a key leaks, revoke it at the vendor dashboard
+#    immediately.
+#
+# 4. For shared team setups, consider using a secrets manager (1Password,
+#    Doppler, Infisical) instead of a plain .env file.


### PR DESCRIPTION
## Summary

Phase 1 of the Pavilion AI in GTM School expansion. Adds 17 new skills and upgrades the bootstrap script to support Bring Your Own Keys (BYOK) and public CLI installation.

All skills follow the established 3-file pattern (`SKILL.md` / `COWORK-PROMPT.md` / `README.md`) and are written for BYOK operators — no references to Octave, Claudeopedia, GTMify Supabase, Genpact, Deepline, PlatformOS, or any other proprietary infrastructure.

## Skills added (17)

**Sales execution (7):**
- `cold-email` — B2B cold emails with 4-touch follow-up sequences
- `abm` — account plan with buying committee map and 30-day multi-channel play
- `battlecard` — honest competitive battlecard with traps, objections, landmines
- `roi-calculator` — risk-adjusted business case with CFO Q&A
- `referral` — warm-intro path finder with forwardable 2-message bundle
- `sequence` — multi-touch multi-channel outreach cadence builder
- `proposal` — customer-facing proposal or SOW with procurement notes

**Cross-functional (6 + roadmap = 7):**
- `brainstorm` — structured multi-frame ideation with ranked output
- `repurpose` — turn one asset into 5-10 derivatives across formats
- `one-pager` — forwardable champion leave-behind doc
- `microsite` — self-contained HTML personalized landing page
- `changelog` — user-facing release notes from git history
- `decision-log` — ADR-style decision capture
- `roadmap` — prioritized roadmap with Now/Next/Later tiers

**File utilities (4):**
- `xlsx` — read/edit/create spreadsheets with openpyxl + pandas
- `docx` — read/edit/create Word documents with python-docx
- `pdf` — extract/merge/split/create/OCR PDFs with pypdf, pdfplumber, weasyprint
- `pptx` — read/edit/create PowerPoint decks with python-pptx

## Bootstrap + tooling upgrades

- New **Phase 6 (Public CLIs):** auto-installs `vercel`, `stripe`, `supabase`, `wrangler`, `agent-browser` via npm
- New **Phase 7 (BYOK .env setup):** interactive prompt copies `setup/env.example` to `~/.claude/.env`, prompts user for the most common keys (Anthropic, OpenAI, Firecrawl, Serper, Apollo, Hunter, HubSpot, Vercel, Stripe), chmod 600
- Managed shell block now **auto-sources** `~/.claude/.env` in every new terminal session
- Bootstrap.ps1 mirrors all of the above for Windows
- `TOTAL_PHASES` bumped from 8 to 10
- `setup/env.example` — fully annotated catalog of every env var any skill might consume, grouped by use case, with which-skill-uses-each notes

## README

- Skill count bumped from 16 to 43 (target post-Phase 3)
- New "Bring Your Own Keys" section linking to `setup/env.example`
- Skills regrouped by Sales / Marketing / Cross-functional / Pipeline / Competitive / CS / Leadership / Daily Ops / File Utilities
- Each row lists optional API keys the skill can consume
- Phase 2 and Phase 3 placeholders marked clearly

## Test plan
- [x] `./setup/bootstrap.sh --check` passes against the updated phase numbering
- [x] All 17 new skill folders contain exactly the 3 required files
- [x] No references to Octave / Claudeopedia / GTMify infra / Genpact / Deepline / PlatformOS in any new skill
- [ ] Human reviewer to confirm tone parity against existing skills
- [ ] Human reviewer to spot-check a skill or two end-to-end in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)