### PR TITLE
Expand Phase 3 + Phase 6 with content/media CLIs the skills actually use

### DIFF
--- a/setup/bootstrap.ps1
+++ b/setup/bootstrap.ps1
@@ -12,10 +12,11 @@
 # What this installs:
 #   Phase 1: Git
 #   Phase 2: winget (package manager)
-#   Phase 3: Developer tools (fnm, jq, gh, fzf, bat, ripgrep, fd, tree)
+#   Phase 3: Developer tools (fnm, jq, gh, ripgrep, fd, bat, fzf, direnv, httpie,
+#            pandoc, poppler, imagemagick, ffmpeg, tesseract, yt-dlp)
 #   Phase 4: Node.js 24 + Python 3.13
 #   Phase 5: Claude Code CLI
-#   Phase 6: Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)
+#   Phase 6: Public CLIs (vercel, stripe, supabase, wrangler, netlify, agent-browser)
 #   Phase 7: Bring Your Own Keys (.env setup)
 #   Phase 8: AI GTM Skills (linked to ~/.claude/skills/)
 #   Phase 9: GitHub authentication
@@ -204,6 +205,21 @@ function Install-Winget {
 Install-Winget "fnm" "Schniz.fnm" "fnm"
 Install-Winget "jq" "jqlang.jq" "jq"
 Install-Winget "gh" "GitHub.cli" "gh"
+Install-Winget "ripgrep" "BurntSushi.ripgrep.MSVC" "rg"
+Install-Winget "fd" "sharkdp.fd" "fd"
+Install-Winget "bat" "sharkdp.bat" "bat"
+Install-Winget "fzf" "junegunn.fzf" "fzf"
+Install-Winget "direnv" "direnv.direnv" "direnv"
+Install-Winget "httpie" "HTTPie.HTTPie" "http"
+
+# Content / file-processing tools (used by docx, pdf, xlsx, pptx, one-pager,
+# microsite, proposal, kit, post-call-summary, contract-review skills)
+Install-Winget "pandoc" "JohnMacFarlane.Pandoc" "pandoc"
+Install-Winget "poppler" "oschwartz10612.Poppler" "pdftotext"
+Install-Winget "imagemagick" "ImageMagick.ImageMagick" "magick"
+Install-Winget "ffmpeg" "Gyan.FFmpeg" "ffmpeg"
+Install-Winget "tesseract" "UB-Mannheim.TesseractOCR" "tesseract"
+Install-Winget "yt-dlp" "yt-dlp.yt-dlp" "yt-dlp"
 
 # ── Phase 4: Runtimes ─────────────────────────────────────────
 Write-Phase 4 "Node.js $FNM_NODE_VERSION + Python $PYTHON_VERSION"
@@ -275,6 +291,7 @@ Install-NpmGlobal "vercel" "vercel"
 Install-NpmGlobal "stripe" "stripe"
 Install-NpmGlobal "supabase" "supabase"
 Install-NpmGlobal "wrangler" "wrangler"
+Install-NpmGlobal "netlify-cli" "netlify"
 Install-NpmGlobal "agent-browser" "agent-browser"
 
 # ── Phase 7: BYOK .env setup ──────────────────────────────────

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -16,10 +16,11 @@
 # What this installs:
 #   Phase 1: Xcode Command Line Tools + Git
 #   Phase 2: Homebrew (macOS package manager)
-#   Phase 3: Developer tools (mise, jq, gh, fzf, bat, ripgrep, fd, tree)
+#   Phase 3: Developer tools (mise, jq, gh, fzf, bat, ripgrep, fd, tree, direnv,
+#            httpie, pandoc, poppler, imagemagick, ffmpeg, tesseract, yt-dlp)
 #   Phase 4: Node.js 24 + Python 3.13 (via mise)
 #   Phase 5: Claude Code CLI
-#   Phase 6: Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)
+#   Phase 6: Public CLIs (vercel, stripe, supabase, wrangler, netlify, agent-browser)
 #   Phase 7: Bring Your Own Keys (.env setup)
 #   Phase 8: AI GTM Skills (linked to ~/.claude/skills/)
 #   Phase 9: GitHub authentication
@@ -343,6 +344,17 @@ brew_install bat
 brew_install ripgrep rg
 brew_install fd
 brew_install tree
+brew_install direnv
+brew_install httpie http
+
+# Content / file-processing tools (used by docx, pdf, xlsx, pptx, one-pager,
+# microsite, proposal, kit, post-call-summary, contract-review skills)
+brew_install pandoc
+brew_install poppler pdftotext
+brew_install imagemagick magick
+brew_install ffmpeg
+brew_install tesseract
+brew_install yt-dlp
 
 # ── Phase 4: Runtimes (Node + Python via mise) ─────────────────
 phase 4 "Node.js $MISE_NODE_VERSION + Python $MISE_PYTHON_VERSION"
@@ -422,7 +434,7 @@ else
 fi
 
 # ── Phase 6: Public CLIs ───────────────────────────────────────
-phase 6 "Public CLIs (vercel, stripe, supabase, wrangler, agent-browser)"
+phase 6 "Public CLIs (vercel, stripe, supabase, wrangler, netlify, agent-browser)"
 
 npm_install_global() {
   local pkg="$1" cmd="${2:-$1}"
@@ -447,6 +459,7 @@ if has_cmd npm; then
   npm_install_global stripe
   npm_install_global supabase
   npm_install_global wrangler
+  npm_install_global netlify-cli netlify
   npm_install_global agent-browser
 else
   warn "npm not available — skipping public CLI installs"


### PR DESCRIPTION
## Summary

The current Phase 3 + Phase 6 install 13 CLIs. Many of the 60 skills in the repo reach for tools that aren't installed — `pandoc` for proposal/docx, `pdftotext` for contract-review, `ffmpeg` for post-call-summary, etc. This PR fills those gaps.

## Phase 3 additions (brew + winget)

| CLI | Used by |
| :-- | :-- |
| `direnv` | All BYOK skills — load `.env` per-project |
| `httpie` (`http`) | API exploration for users debugging their own keys |
| `pandoc` | `docx`, `proposal`, `one-pager`, `changelog`, `kit`, `qbr-builder` |
| `poppler` (`pdftotext`) | `pdf`, `contract-review`, `vendor-evaluation` |
| `imagemagick` (`magick`) | `microsite`, `one-pager` |
| `ffmpeg` | `post-call-summary`, content workflows |
| `tesseract` | `pdf`, `contract-review` (scanned docs) |
| `yt-dlp` | `prospect-research`, `competitive-intel`, content repurposing |

## Phase 6 additions (npm)

| CLI | Used by |
| :-- | :-- |
| `netlify-cli` | Vercel alternative for `microsite`, `one-pager` static deploys |

## Deliberately skipped

- `gcloud` / `awscli` — heavy installs, can add later if users ask
- `doctl`, `flyctl`, `railway` — alternative hosting; netlify covers the Vercel-alternative case
- `op` (1Password) — requires paid 1P account, not class-friendly

## Test plan

- [x] `bash -n setup/bootstrap.sh` syntax check passes
- [ ] Run `setup/bootstrap.sh --check` on a clean Mac
- [ ] Verify each new CLI lands on PATH and `--version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)