### PR TITLE
docs: add 101 starter set + 201 companion link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This repo contains 16 ready-to-use AI agent skills for go-to-market and revenue leadership. Skills are installed to `~/.claude/skills/` by the bootstrap script.
 
+**First week?** Start with five: `meeting-prep`, `prospect-research`, `deal-strategy`, `pipeline-health`, `post-call-summary`. They cover the full revenue motion and are the same five the Session 5 demos walk through. Once those feel automatic, the [Power Prompting 201](https://aigtmschool2026q2.vercel.app/power-prompting-201) reference covers the compounding moves (chaining, custom Layer 1 patterns, anti-hallucination constraints, JSON output, when *not* to use a skill).
+
 ## Available Skills
 
 | Skill | Trigger Phrases |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ If you're here from Pavilion's **Operations: Power Prompting for Revenue Teams**
 
 ---
 
+## Start Here — 5 Skills (101)
+
+61 skills is a firehose. If this is your first install, ignore the other 56 for the first week and run these five. They cover the full revenue motion, every one fires on a natural phrase, and they're the same five the Session 5 demos walk through:
+
+| Skill | Trigger phrase | When you'd reach for it |
+|---|---|---|
+| [Meeting Prep](skills/meeting-prep/) | *"prep me for my call with [company]"* | Before any external meeting |
+| [Prospect Research](skills/prospect-research/) | *"research [company]"* | Account warm-up; outbound list work |
+| [Deal Strategy](skills/deal-strategy/) | *"deal strategy for [account]"* | Mid-funnel deal you need a plan on |
+| [Pipeline Health](skills/pipeline-health/) | *"audit my pipeline"* | Monday morning, end of week, commit calls |
+| [Post-Call Summary](skills/post-call-summary/) | *"summarize my call"* | Within 10 min of any customer call |
+
+Customize **Layer 1 (Context)** in any one of them with your company / ICP / competitors and the output quality jumps an order of magnitude. The bootstrap onboarding sets a global Context in `~/.claude/CLAUDE.md` — every skill inherits it.
+
+## Once You're Fluent (201)
+
+When the Six-Layer Stack feels obvious and you want the moves that compound across skills — chaining, custom Layer 1 patterns, anti-hallucination constraints at scale, JSON output for chained pipelines, and *when not to use a skill* — read the 201 companion: **[Power Prompting 201](https://aigtmschool2026q2.vercel.app/power-prompting-201)**.
+
+---
+
 ## See It in Action
 
 Before installing anything, see what these skills produce:


### PR DESCRIPTION
## Summary
- README gets two new sections at the top: **Start Here — 5 Skills (101)** (meeting-prep, prospect-research, deal-strategy, pipeline-health, post-call-summary with triggers + use cases) and **Once You're Fluent (201)** linking the `/power-prompting-201` companion page.
- CLAUDE.md gets one parallel sentence so the same guidance fires whenever Claude loads the repo.

## Why
Cohort-1 Session 5 feedback (Feb 2026) scored format / topics 0.8 below cohort average — the room needed a glide path. The takeaway page already has a 101 / 201 split; this mirrors it inside the repo so a fresh installer gets the same orientation rather than 61 undifferentiated skill folders.

No file moves, no skill changes, no path-only triggers, no CI assertions touched.

## Test plan
- [ ] CI green (bootstrap-smoke-test on macOS + Windows)
- [ ] README renders with the two new sections above "See It in Action"
- [ ] CLAUDE.md onboarding still works end-to-end with the new opening sentence
- [ ] Link to `/power-prompting-201` works once the pavilion-ai-gtm-school repo deploys (separate PR landed today)

Targets merge before Tue 8am ET public flip.