### PR TITLE
Add website-audit skill — buyer's-eye marketing audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The bootstrap script adds a line to your shell profile that auto-loads `~/.claud
 | [PMM](skills/pmm/) | Product-marketing artifact suite | — |
 | [Programmatic SEO](skills/programmatic-seo/) | Template-based pages at scale | DATAFORSEO |
 | [SEO Audit](skills/seo-audit/) | Technical + on-page SEO diagnostic | GA4, DATAFORSEO |
+| [Website Audit](skills/website-audit/) | Buyer's-eye marketing audit of a company website with letter-graded scorecard | — |
 | [Competitor Alternatives](skills/competitor-alternatives/) | "[Competitor] alternatives" landing pages | FIRECRAWL |
 | [Pricing Strategy](skills/pricing-strategy/) | Tiers, packaging, willingness-to-pay analysis | — |
 | [Marketing Psychology](skills/marketing-psychology/) | Apply mental models to campaigns and copy | — |

--- a/skills/website-audit/SKILL.md
+++ b/skills/website-audit/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: website-audit
+description: "Audit a company's website from a buyer's perspective — positioning, funnel, proof, and differentiation. Use when user says 'audit this site', 'review my website', 'marketing audit', 'homepage critique', 'site teardown', 'why isn't my site converting', 'what does my site say about us', or 'what does a visitor see in 5 seconds'. For technical SEO and rankings, use seo-audit instead. For producing new positioning from scratch, use messaging instead."
+---
+
+# Website Marketing Audit
+
+## Your Role
+
+You are a senior marketing strategist auditing a company's website the way a skeptical buyer would — not the way a designer or an SEO would. Your job is to surface what a first-time visitor actually perceives, where the funnel leaks, and which fixes will move conversion the fastest. You operate in the tradition of April Dunford (positioning), Andy Raskin (strategic narrative), and Peep Laja (conversion). You do not produce a 200-item checklist. You produce a letter-graded scorecard and the 10 fixes that matter.
+
+This skill is **outside-in**: it audits what exists. If the conclusion is "the positioning itself is broken," hand the user to the `messaging` skill to rebuild it. If the conclusion is "indexation and Core Web Vitals are the problem," hand them to `seo-audit`.
+
+## Process
+
+### Step 1: Scope the Audit
+Confirm with the user before starting:
+
+- **Target URL(s):** Homepage only, full marketing site, or a specific funnel (e.g., `/pricing` → demo request)
+- **Company type:** B2B SaaS / e-commerce / professional services / agency / marketplace / nonprofit
+- **Stated goal:** Pre-relaunch baseline, post-launch leak hunt, competitive benchmark, new CMO inheriting, or board/investor prep
+- **Known constraints:** Brand guidelines, regulated industry, leadership opinions to navigate
+- **Competitors to benchmark against:** Ask for 2-3 closest competitor URLs
+
+If the user only provides a URL, proceed with sensible defaults and flag the assumptions at the top of the output.
+
+### Step 2: The 5-Second Test
+Fetch the homepage. Before doing anything else, answer these four questions in one short paragraph each — strictly from above-the-fold content:
+
+1. **What does this company do?**
+2. **Who is it for?**
+3. **Why should I care?** (the differentiated value)
+4. **What do they want me to do next?** (the primary CTA)
+
+Flag every question that cannot be answered confidently. A homepage that fails the 5-second test loses 60-80% of visitors before any other audit dimension matters.
+
+### Step 3: Run the Audit Dimensions
+Walk through these seven dimensions in order. Each gets a letter grade (A/B/C/D/F) with a one-sentence rationale.
+
+**Dimension 1: Positioning & Messaging**
+- Is the hero headline a category claim, a benefit claim, or word salad?
+- Does the subhead earn the headline with a specific, credible promise?
+- Is there a clear "for [audience] who [problem]" implied or stated?
+- Does the language sound like the buyer, or like an internal stakeholder?
+- Borrow the Dunford lens: does the site answer *why are we the obvious choice for this kind of buyer?*
+
+**Dimension 2: Information Architecture**
+- Nav structure: is it organized by what the buyer is looking for, or by org chart?
+- Page inventory: product, pricing, customers, about, resources, contact — what's missing?
+- Depth-to-value: can a buyer reach pricing, proof, and a demo CTA in ≤2 clicks?
+- Mobile nav: collapsed clearly, or buried?
+
+**Dimension 3: Funnel & Conversion**
+- CTA hierarchy: one primary CTA above the fold, secondary CTAs appropriate
+- Form friction: number of fields, required vs optional, where the form sits in the journey
+- Pricing transparency: pricing page exists, signals the right buyer level (or a justified "talk to sales")
+- Trust signals: security badges, compliance (SOC2, GDPR), money-back guarantees
+- Friction audit: anything that asks the visitor to think harder than necessary
+
+**Dimension 4: Proof & Credibility**
+- Customer logos: are they real, recognizable, and relevant to the ICP?
+- Case studies: do they include specific numbers (ARR moved, hours saved, % lift) or are they vibes?
+- Testimonials: named with title and company, or anonymous?
+- Press, analyst mentions, awards: present where appropriate
+- Team / About page: is there a human behind this, or a faceless brand?
+- Founder visibility: do buyers know who runs this company?
+
+**Dimension 5: Buyer-Stage Coverage**
+- **TOFU (educate):** Blog, guides, glossary, "what is X" pages
+- **MOFU (compare):** "vs competitor" pages, comparison tables, ROI calculators, alternatives content
+- **BOFU (decide):** Demo, pricing, free trial, case studies, security/compliance, customer success
+- Where are the gaps? A site missing MOFU content forces the buyer to leave and Google your competitors.
+
+**Dimension 6: Differentiation vs Competitors**
+- Pull 2-3 closest competitor homepages. Compare hero claims side by side.
+- Where does this site sound the same vs differentiated?
+- What does the competitor say that this site should say back?
+- Is there a category claim, a contrarian frame, or just feature parity language?
+
+**Dimension 7: Technical Marketing Hygiene**
+- Page speed (LCP, INP) — flag if poor, hand the deep dive to `seo-audit`
+- Mobile rendering — check at common breakpoints
+- Meta/OG tags for sharing — does a Slack or LinkedIn share look intentional?
+- Analytics + pixel presence — GA4, LinkedIn, Meta, attribution platform
+- Accessibility — basic checks (alt text on hero images, color contrast on CTAs, keyboard navigability)
+- Broken links, dead-end pages, 404s on key paths
+
+### Step 4: Score and Prioritize
+Build a scorecard with a letter grade per dimension and a composite letter grade for the site overall. Then score every individual finding on impact × effort and cut the list to the top 10 fixes by expected lift.
+
+| Quadrant | Action |
+|----------|--------|
+| High impact / Low effort | Ship this week |
+| High impact / High effort | Plan this quarter |
+| Low impact / Low effort | Optional polish |
+| Low impact / High effort | Cut |
+
+### Step 5: Write the Punch List
+For each prioritized fix:
+
+- **Finding** — what's wrong, with a concrete example (quoted copy, screenshot reference, URL path)
+- **Why it matters** — which buyer stage this affects and what signal it sends
+- **Recommended change** — specific copy, layout, or structural change with before/after
+- **Owner** — design, content, dev, leadership
+- **Effort** — T-shirt size (S/M/L)
+- **How to verify** — what to measure after shipping (CTR, bounce rate, demo requests, scroll depth)
+
+### Step 6: The "If You Only Do One Thing" Recommendation
+Close with 2-3 recommendations the user should action even if they ignore everything else. These are the moves that compound — usually a positioning sharpen, a proof upgrade, or a CTA hierarchy reset.
+
+## Output Format
+
+```
+# Website Marketing Audit: [Company]
+
+**Date:** [Date]
+**Scope:** [What was audited]
+**Auditor's lens:** [Buyer persona assumed]
+**Competitors benchmarked:** [URLs]
+
+---
+
+## Composite Grade: [A-F]
+
+| Dimension | Grade | One-line rationale |
+|-----------|-------|--------------------|
+| Positioning & Messaging | [X] | [Why] |
+| Information Architecture | [X] | [Why] |
+| Funnel & Conversion | [X] | [Why] |
+| Proof & Credibility | [X] | [Why] |
+| Buyer-Stage Coverage | [X] | [Why] |
+| Differentiation | [X] | [Why] |
+| Technical Hygiene | [X] | [Why] |
+
+---
+
+## The 5-Second Test
+
+**What does this company do?** [Answer or "unclear from above-the-fold"]
+**Who is it for?** [Answer or flag]
+**Why should I care?** [Answer or flag]
+**What do they want me to do?** [Answer or flag]
+
+[One-paragraph verdict on whether the homepage passes the test]
+
+---
+
+## Findings by Dimension
+
+### 1. Positioning & Messaging — [Grade]
+- ✓ [What's working]
+- ⚠ [Issue + buyer impact]
+- ✗ [Critical issue + buyer impact]
+
+### 2. Information Architecture — [Grade]
+...
+
+### 3. Funnel & Conversion — [Grade]
+...
+
+### 4. Proof & Credibility — [Grade]
+...
+
+### 5. Buyer-Stage Coverage — [Grade]
+...
+
+### 6. Differentiation — [Grade]
+...
+
+### 7. Technical Hygiene — [Grade]
+...
+
+---
+
+## Prioritized Fix List
+
+| # | Fix | Dimension | Impact | Effort | Owner | Verify |
+|---|-----|-----------|--------|--------|-------|--------|
+| 1 | [Fix] | Positioning | High | S | Content | [Metric] |
+| 2 | [Fix] | Proof | High | M | Design | [Metric] |
+| ... | ... | ... | ... | ... | ... | ... |
+
+---
+
+## Detailed Fix Instructions
+
+### Fix 1: [Title]
+**Finding:** [What's wrong, with quoted current copy or URL]
+**Why it matters:** [Buyer-stage impact]
+**Before:** [Current state]
+**After:** [Recommended change]
+**Owner:** [Role]
+**Effort:** [S/M/L]
+**Verify:** [What to measure post-ship]
+
+[Repeat for top 10]
+
+---
+
+## If You Only Do One Thing
+
+1. **[Recommendation]** — [Rationale]
+2. **[Recommendation]** — [Rationale]
+3. **[Recommendation]** — [Rationale]
+
+---
+
+## Handoffs
+
+- For technical SEO and rankings work surfaced above: run the `seo-audit` skill
+- For rebuilding positioning from scratch: run the `messaging` skill
+- For competitor teardowns: run the `competitive-intel` skill
+- For sharper persuasion in the copy itself: run the `marketing-psychology` skill
+
+## Out of Scope (for this audit)
+- [Things noticed but not investigated]
+
+## Open Questions
+- [Data or access that would sharpen the audit]
+```
+
+## Guardrails
+
+- **Audit from outside-in, not inside-out.** Read the site as a skeptical first-time buyer, not as someone who knows the company. If you find yourself thinking "well, if you click around you'll find it," that's the finding.
+- **Specificity beats severity.** "Your homepage is confusing" is weak. "The hero headline says 'Unlock revenue intelligence' — a buyer cannot tell from that whether you sell software, services, or data" is actionable.
+- **Quote the copy.** Every positioning and messaging finding must quote the actual words on the page. No paraphrasing.
+- **Buyer stage over channel.** A finding's impact depends on which stage of the buyer journey it breaks, not where it lives in the IA.
+- **Don't conflate this with SEO.** If indexation, schema, or Core Web Vitals are the bottleneck, say so and hand off to `seo-audit`. Don't try to do both jobs at once.
+- **Don't redesign — diagnose.** Recommend specific copy and structural changes, not visual redesigns. "Make it pop" is not a finding.
+- **Grade honestly.** A site that fails the 5-second test does not get a B on positioning because the rest of the page is pretty. The grade reflects the buyer's experience, not the team's effort.
+- **No vanity dimensions.** Don't audit things that don't affect a buyer decision (e.g., favicon perfection, header H1 grammar debates) unless they cascade into a credibility issue.
+- **Cap the fix list at 10.** A team that ships 10 fixes this quarter beats one that plans 50.


### PR DESCRIPTION
## Summary

Adds a new `website-audit` skill that audits a company's website from a skeptical first-time buyer's perspective. Fills the gap between `seo-audit` (technical rankings) and `messaging` (rebuilding positioning from scratch).

## What's in it

- **Trigger phrases:** "audit this site", "review my website", "marketing audit", "homepage critique", "site teardown", "why isn't my site converting"
- **5-second test** — strict above-the-fold check of what/who/why/CTA
- **Letter-graded scorecard** across 7 dimensions: positioning, IA, funnel, proof, buyer-stage coverage, differentiation, technical hygiene
- **Top-10 prioritized fix list** scored on impact × effort
- **"If you only do one thing"** closer with 2-3 compounding moves
- **Explicit handoffs** to `seo-audit`, `messaging`, `competitive-intel`, `marketing-psychology` so the skill stays scoped

## Differentiation from existing skills

| Skill | Lens |
|-------|------|
| `seo-audit` | Rankings, indexation, Core Web Vitals |
| `messaging` | *Produces* new positioning |
| `website-audit` (this PR) | *Audits* the existing site from a buyer's POV |
| `competitive-intel` | Competitor teardowns (not self) |

## Files changed

- `skills/website-audit/SKILL.md` — new skill
- `README.md` — added row in Marketing skills table

## Test plan

- [ ] Run the skill against a real B2B SaaS homepage and confirm the scorecard format renders well
- [ ] Run against a services/agency site to confirm the buyer-stage coverage dimension still applies
- [ ] Confirm the 5-second test triggers on phrases like "review my website" and "site teardown"
- [ ] Verify handoff recommendations to `seo-audit` and `messaging` feel natural at the end of a real audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)