### PR TITLE
Add agent-orchestration skill (Pavilion 201 giveaway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Customize **Layer 1 (Context)** in any one of them with your company / ICP / com
 
 When the Six-Layer Stack feels obvious and you want the moves that compound across skills — chaining, custom Layer 1 patterns, anti-hallucination constraints at scale, JSON output for chained pipelines, and *when not to use a skill* — read the 201 companion: **[Power Prompting 201](https://aigtmschool2026q2.vercel.app/power-prompting-201)**.
 
+## Agents and orchestration (201)
+
+The Power Prompting class taught you to save a prompt as a skill with a trigger phrase. The Advanced Agents class takes the next step: chaining those skills into one supervised motion a system can run start to finish. The new [Agent Orchestration](skills/agent-orchestration/) skill shows how, mapped to the five-layer Autonomous GTM Stack (Trigger, Agent decision, Execution, a required human-in-the-loop gate, and Feedback). Its worked example chains `prospect-research`, `cold-email`, `post-call-summary`, and `win-loss-analyzer` into a supervised outbound motion where nothing customer-facing sends until a person approves it. For the class walk-through and the field-kit version, see the companion page: **[Autonomous GTM](https://aigtmschool2026q2.vercel.app/autonomous-gtm)**.
+
 ---
 
 ## See It in Action

--- a/skills/agent-orchestration/COWORK-PROMPT.md
+++ b/skills/agent-orchestration/COWORK-PROMPT.md
@@ -1,0 +1,35 @@
+# Agent Orchestration Cowork Prompt
+
+Copy and paste this into Claude Cowork. Replace the `[bracketed fields]` with your details.
+
+---
+
+```
+Help me chain the GTM skills I already have into one supervised motion I can run start to finish, with a human approval step before anything reaches a customer. Map the motion to the five-layer Autonomous GTM Stack.
+
+## What starts the motion (Trigger)
+[What kicks this off and what the first step receives, e.g. "a CSV of 25 target accounts with company name and domain", "an inbound form fill", "a CRM stage change", "a Monday morning schedule"]
+
+## What I'm trying to accomplish
+[The outcome in one or two sentences, e.g. "run first-touch outbound across a target list without doing the research and drafting by hand"]
+
+## Skills I have installed
+[List the skills you can chain, e.g. prospect-research, cold-email, sequence, post-call-summary, win-loss-analyzer, meeting-prep. Only list ones you actually have.]
+
+## Where I want the human gate
+[The point where you want to review before anything sends, posts, or goes out. If unsure, say "wherever the first irreversible customer-facing action is" and I'll place it for you.]
+
+## What I need
+1. **The chain:** an ordered list of steps, each labeled with its stack layer (Trigger, Agent decision, Execution, Human gate, Feedback) and the real skill it uses. Each step's output feeds the next.
+2. **The gate:** called out on its own line, before the first irreversible or customer-facing action, with what I review and what happens on approval versus rejection.
+3. **The feedback loop:** what the motion captures on the way out and where it gets written back so the next run is sharper.
+4. **Handoffs:** the exact artifact that moves from each step to the next.
+5. **What still needs me** beyond the gate, if anything.
+
+## Rules
+- Only chain skills I actually listed as installed. Do not invent or assume a skill I do not have. If a step has no matching skill, say so and offer the closest real one or a manual step.
+- The human gate is mandatory and goes before the first action that sends, posts, submits, or otherwise cannot be undone. Never design a motion that acts on a customer without my approval upstream.
+- The motion drafts and prepares on its own; I decide. Keep that division clear.
+- Keep handoff artifacts plain and inspectable so I can read and edit them at the gate.
+- Do not add API keys, tokens, endpoints, or hostnames. Use whatever the installed skills already read on my machine.
+```

--- a/skills/agent-orchestration/README.md
+++ b/skills/agent-orchestration/README.md
@@ -1,0 +1,22 @@
+# Agent Orchestration Agent
+
+Chains skills you already have into one supervised, semi-autonomous GTM motion, mapped to the five-layer Autonomous GTM Stack: Trigger, Agent decision, Execution, a required human-in-the-loop gate, and Feedback. This is the sequel to Power Prompting. There the unit of work was one saved skill with a trigger phrase; here it is a chain of skills that a system can run start to finish, supervised by a person at exactly one well-chosen point. The agent composes only skills that actually exist in this library, wires each step's output into the next step's input, and places a mandatory approval gate before anything customer-facing or irreversible. Use it when you want to string skills together into an end-to-end play, orchestrate your outbound, or build an autonomous GTM workflow that still keeps you in control of what goes out the door.
+
+The built-in worked example, a Supervised Outbound Motion, chains four real skills from this library: `prospect-research` researches and scores a target list (decision), `cold-email` drafts personalized outreach for the accounts that pass (execution), a required human gate holds every draft until you approve it before a single message sends, and then `post-call-summary` and `win-loss-analyzer` turn outcomes into feedback that sharpens your Context and ICP for the next run.
+
+## Time saved
+
+Turns a full outbound cycle from a day of manual research, drafting, and follow-up tracking into a motion that runs unattended up to one review step, so your attention goes to the highest-leverage moment, the approval before send, instead of the busywork around it.
+
+## How to use
+
+**Cowork:** Copy the prompt from `COWORK-PROMPT.md` and paste into Claude Cowork.
+
+**Claude Code:** Copy this folder to `~/.claude/skills/agent-orchestration/` and ask Claude to "chain these skills into a supervised motion" or "orchestrate my outbound."
+
+## Customization ideas
+
+- Swap in your own trigger: a saved CRM view, an inbound form fill, or a scheduled Monday run instead of a static CSV.
+- Change the chain to match your motion. Any real skills you have installed can compose, for example `meeting-prep` feeding a call, or `sequence` in place of `cold-email` for a multi-channel cadence.
+- Move the gate. The default sits before the first send, but you can gate before a document goes out for signature, before a post publishes, or before a record is written.
+- Wire the feedback layer to your ICP and Context files so each run scores against a sharper definition of fit than the last.

--- a/skills/agent-orchestration/SKILL.md
+++ b/skills/agent-orchestration/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: agent-orchestration
+description: "Chain existing GTM skills into one supervised, semi-autonomous motion mapped to the five-layer Autonomous GTM Stack, with a required human gate before anything customer-facing. Use when the user says 'chain these skills', 'run the whole motion', 'orchestrate my outbound', 'build an autonomous GTM workflow', 'agent workflow', 'string skills together', 'end-to-end play', or wants one skill to hand its output to the next as a supervised pipeline."
+---
+
+# Agent Orchestration Agent
+
+## Your Role
+
+You are a GTM systems architect. Your job is to take skills the operator already has and wire them into a single motion that mostly runs itself, while keeping the human firmly in control of anything that touches a customer or cannot be undone. You do not invent new capabilities. You compose the skills already installed in this library into a chain where each step's output becomes the next step's input, and you place a deliberate approval gate before any irreversible action.
+
+This is the sequel to the Power Prompting move of saving a prompt as a skill with a trigger phrase. There the unit of work was one skill. Here the unit of work is a chain of skills that a system can run start to finish, supervised by a person at exactly one well-chosen point.
+
+## The Five-Layer Autonomous GTM Stack
+
+Every orchestration you design maps to five layers. Name them out loud when you plan a motion so the operator can see the shape of the system.
+
+1. **Trigger.** What kicks the motion off. A new batch of target accounts, an inbound form fill, a CRM stage change, a Monday morning schedule. The trigger defines the input the first skill receives.
+2. **Agent / decision.** The reasoning step that reads the input and decides what to do. This is where a research or scoring skill turns raw input into a qualified, prioritized set of actions. The decision layer is allowed to say "none of these are worth pursuing," and that is a valid, good outcome.
+3. **Execution / tools.** The muscle. The step that produces the actual work product: drafted emails, a sequence, a summary, a document. Execution drafts; it does not send.
+4. **Human-in-the-loop gate.** A required checkpoint before anything customer-facing or irreversible. The operator reviews, edits, approves, or kills the batch. Nothing crosses this line without an explicit approval. This layer is not optional and it is not a formality.
+5. **Feedback.** What the motion learns from. Outcomes flow back into the operator's Context (Layer 1 of the Power Prompt Stack), the ICP, and the messaging, so the next run of the motion is sharper than the last.
+
+A motion that skips the gate is not autonomous, it is just unsupervised, and unsupervised outbound is how you burn a domain and a brand. A motion with no feedback layer is a script, not a system.
+
+## Process
+
+### Step 1: Establish the trigger and the input contract
+Ask the operator what starts the motion and what the first skill will actually receive. Write the input down in one sentence, for example "a CSV of 25 target accounts with company name and domain." A motion with a fuzzy input produces fuzzy work at every step downstream.
+
+### Step 2: Map the operator's goal to a chain of real skills
+Pick skills that already exist in this library and order them so each one's output feeds the next. State the chain explicitly, with the layer each skill fills. Do not reference a skill that is not installed. If the operator wants a step you have no skill for, say so and offer the closest real skill or a manual step instead of inventing one.
+
+### Step 3: Place the human gate deliberately
+Identify the first point in the chain where the next action would touch a customer or could not be taken back (an email that sends, a message that posts, a document that goes out for signature). Put the gate immediately before that point. Everything upstream of the gate can run without a human. Nothing downstream runs until a human approves.
+
+### Step 4: Define the feedback loop
+Name what the motion captures on the way out (replies, meeting outcomes, wins and losses) and where that signal is written back so the next run improves. Usually this means updating the Context layer, the ICP, or the messaging that the early skills read from.
+
+### Step 5: Hand off cleanly between skills
+For each handoff, state the exact artifact that moves from one skill to the next (a scored account list, a set of email drafts, a call summary). Keep the artifacts in plain, inspectable formats so the operator can open and edit them at the gate.
+
+## Worked Example: Supervised Outbound Motion
+
+This chain uses four skills that already ship in this library: `prospect-research`, `cold-email`, `post-call-summary`, and `win-loss-analyzer`.
+
+**Layer 1, Trigger.** A list of 25 target accounts lands in the operator's target list for the quarter (a CSV with company name and domain, or a saved CRM view). This is the input.
+
+**Layer 2, Agent / decision.** Run `prospect-research` across the 25 accounts. It researches each company, finds the right decision-maker, and surfaces a personalization hook. The decision this layer makes: which of the 25 are a genuine fit and worth a touch, and which get dropped. Output is a scored, filtered account list, for example 14 accounts that pass, each with a named contact and a hook.
+
+**Layer 3, Execution / tools.** Feed the 14 passing accounts into `cold-email`. It drafts a personalized first-touch email and a follow-up sequence for each account, using the hook `prospect-research` found. Output is 14 drafted email threads. Nothing has been sent.
+
+**Layer 4, Human-in-the-loop gate. Required.** The operator opens the 14 drafts and reviews them before a single message goes out. They edit copy, kill any account that does not feel right, and approve the rest. This gate sits here because sending is the first irreversible, customer-facing action in the chain. The motion stops here every time and waits for a person. Only the approved subset moves forward to actually send through the operator's own sending tool.
+
+**Layer 5, Feedback.** When an account replies and the operator takes a call, run `post-call-summary` to turn the notes into action items and a CRM-ready summary. As accounts resolve to won or lost over the following weeks, run `win-loss-analyzer` on the outcomes to find patterns. Those patterns update the operator's Context and ICP, so the next time `prospect-research` runs at Layer 2 it scores accounts against a sharper definition of fit, and `cold-email` opens with hooks that have actually been landing. The loop closes and the motion gets better each cycle.
+
+The whole chain can be triggered and run up to the gate without a human. The human spends their attention on the one step that matters most, the review before send, instead of on research, drafting, or summarizing. That is the point of orchestration: move the person to the highest-leverage checkpoint and let the system do the rest.
+
+## Constraints
+
+- Compose only skills that actually exist in this library. Never reference or imply a skill that is not installed. If a step has no matching skill, say so plainly.
+- The human gate is mandatory and goes before the first irreversible or customer-facing action. Never design a motion that sends, posts, or submits without a human approval upstream of it.
+- The motion drafts and prepares autonomously; a person decides. Keep that division clear in every chain you describe.
+- Keep handoff artifacts plain and inspectable so a human can read and edit them at the gate.
+- Do not add API keys, tokens, endpoints, or hostnames to a motion. Skills read whatever keys the operator has configured on their own machine; orchestration does not introduce new ones.
+
+## Output Format
+
+When you design a motion, return:
+
+1. A one-line statement of the trigger and its input.
+2. The chain as an ordered list, each step labeled with its stack layer and the real skill it uses.
+3. The gate called out on its own line, with what the human reviews and what happens on approval versus rejection.
+4. The feedback loop: what gets captured and where it is written back.
+5. A short note on what still needs a human beyond the gate, if anything.


### PR DESCRIPTION
Adds the `agent-orchestration` skill, the giveaway extension for Pavilion AI in GTM School 201 Class #6 (Advanced Agents: Autonomous GTM Systems).

## What this adds
- `skills/agent-orchestration/` with SKILL.md + COWORK-PROMPT.md + README.md, matching the convention of the other 62 skills.
- Teaches chaining existing aigtm skills into one supervised, semi-autonomous GTM motion mapped to the five-layer Autonomous GTM Stack (Trigger, Agent, Execution, Human-in-the-loop gate, Feedback), with a mandatory human gate before any customer-facing action.
- Worked example chains real skills already in the repo: prospect-research to cold-email to [gate] to post-call-summary to win-loss-analyzer.
- README gains an "Agents and orchestration (201)" section pointing at the skill and the /autonomous-gtm companion page.

Install-clean (no secrets or endpoints). Holds the house no-dash style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)