### PR TITLE
Fix Windows Quick Start: install git before cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,43 @@ See the full breakdown in [What Gets Installed](#what-gets-installed) below.
 
 ### Windows (PowerShell)
 
+Windows takes three steps rather than one command. The macOS version can be piped straight from the network because `curl` ships with the OS, but on Windows the script has to be on disk before it can run, and `git` is what puts it there.
+
+Work in a normal PowerShell window, **not** an elevated one. Everything installs into your own user profile, so an Administrator prompt puts it in the wrong place. If your prompt opens at `C:\WINDOWS\system32`, you are elevated: close it and open PowerShell as your regular user.
+
+**1. Install git.**
+
 ```powershell
-git clone https://github.com/GTMify/aigtm.git $env:USERPROFILE\claude\aigtm
-~\claude\aigtm\setup\bootstrap.ps1
+winget install --id Git.Git -e --source winget
 ```
 
-Requires winget (built into Windows 11, available via App Installer on Windows 10). After setup, close and reopen your terminal, then run `claude`.
+winget is built into Windows 11 and available through App Installer on Windows 10. If `winget` is not recognized, install App Installer from the Microsoft Store, or download git from [git-scm.com](https://git-scm.com/download/win).
+
+**2. Close PowerShell and open it again.** This step is required, not tidiness. winget does not update the `PATH` of a session that is already running, so `git` stays unrecognized until you start a new window.
+
+**3. Clone and run.**
+
+```powershell
+git clone https://github.com/GTMify/aigtm.git $env:USERPROFILE\claude\aigtm
+cd $env:USERPROFILE\claude\aigtm
+.\setup\bootstrap.ps1
+```
+
+Note the `.\` and the `cd`. PowerShell will not execute a script from a bare path in command position, and it does not expand `~` there either, so a line like `~\claude\aigtm\setup\bootstrap.ps1` fails with a confusing complaint about a module that could not be loaded. To run it from some other directory, use the call operator instead: `& "$env:USERPROFILE\claude\aigtm\setup\bootstrap.ps1"`.
+
+If PowerShell refuses with a message about running scripts being disabled, allow it for the current session only:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+Phase 1 of the script installs git as well, which is harmless if step 1 already did. Prefer `.\setup\bootstrap.ps1 -Check` first if you want a read-only health report before anything changes. After setup finishes, close and reopen your terminal, then run `claude`.
+
+**Just want Claude Code and none of the GTM skills?** Skip this repo entirely. The official installer brings its own runtime, so it needs neither git nor Node:
+
+```powershell
+irm https://claude.ai/install.ps1 | iex
+```
 
 ### Claude Desktop / Cowork (no install required)
 


### PR DESCRIPTION
## The bug

The Windows Quick Start instructs the reader to `git clone` this repo before running `setup/bootstrap.ps1`. But **Phase 1 of that same script is what installs git**, so a clean Windows machine cannot get past the first line.

Reported by a new user on a clean Windows box, running the documented commands verbatim:

```
git : The term 'git' is not recognized as the name of a cmdlet, function, script file,
or operable program.

~\claude\aigtm\setup\bootstrap.ps1 : The module '~' could not be loaded.
```

The second error is a separate defect in the same two lines: PowerShell will not execute a script from a bare path in command position, and it does not expand `~` there, so it attempted module auto-loading and reported a missing module rather than a missing file.

macOS is unaffected because its one-liner pipes through `curl`, which ships with the OS.

## Why the macOS fix does not transfer

The obvious symmetric fix would be `irm https://raw.githubusercontent.com/.../bootstrap.ps1 | iex`. That does not work. `bootstrap.ps1:59` derives its own location:

```powershell
$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
$RepoDir = Split-Path -Parent $ScriptDir
```

Piped to `iex`, `$MyInvocation.MyCommand.Path` is empty, so `$RepoDir` is empty and Phase 7 (`setup/env.example`) and Phase 8 (`skills`) both resolve to nothing. Phase 8 would link zero skills while the script reported success. So the script genuinely has to run as a file from inside the clone, and the documentation has to install git first.

## The change

Documentation only. No change to `bootstrap.ps1`.

1. Lead with `winget install --id Git.Git -e --source winget`.
2. Require a PowerShell restart between installing git and using it, since winget does not update `PATH` for a session already running. This is the step most likely to be skipped, so it is called out as required rather than suggested.
3. `cd` into the repo and invoke `.\setup\bootstrap.ps1`, matching the script's own documented usage. Documents the call operator form for running it from another directory.
4. Warn against an elevated window. Every phase installs per-user, so an Administrator prompt writes to the wrong profile. The reporter's prompt was at `C:\WINDOWS\system32`, which is the tell.
5. Add the process-scoped `ExecutionPolicy` escape hatch, the next thing likely to block a Windows reader.
6. Add a pointer to the official Claude Code installer for anyone who wants the CLI without the 61 GTM skills.

## Suggested follow-up, deliberately not in this PR

`bootstrap.ps1` could fall back to a fixed `$env:USERPROFILE\claude\aigtm` and self-clone when `$MyInvocation.MyCommand.Path` is empty, which is what `bootstrap.sh` already does at lines 562 and 573. That would allow a true Windows one-liner and bring the two platforms to parity. It is a behavior change to an installer that I cannot exercise on Windows from here, so it should be a separate PR tested on a real Windows box rather than bundled into a docs fix.

## Verification

Read-only static verification, since I have no Windows machine here:

- `npm view @anthropic-ai/claude-code engines` returns `{ node: '>=22.0.0' }`, so the official-installer pointer is the correct advice for a machine with no runtime.
- `curl -sI https://claude.ai/install.ps1` resolves (302 to `downloads.claude.ai/claude-code-releases/bootstrap.ps1`), and the script refuses 32-bit Windows, verifies a SHA256 checksum, and installs under `$env:USERPROFILE\.claude`.
- Grepped the repo: no other doc or script carries the broken invocation pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)